### PR TITLE
Create blogs given from parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,14 @@ class ghost(
   validate_hash($blogs)
   validate_hash($blog_defaults)
 
+  # Create resources from parameters
+  create_resources(
+    'ghost::blog',
+    $blogs,
+    $blog_defaults
+  )
+
+  # Create resource from Hiera
   create_resources(
     'ghost::blog',
     hiera_hash('ghost::blogs', {}),


### PR DESCRIPTION
Right now, the example puppet code of:

``` puppet
 class { ghost:
   blogs => {
     # The name, url, and port must be different per instance!
     'my_blog' => {
       'url'  => 'http://my-first-ghost-blog.com',
     }
   }
 }
```

doesn't actually work. It'll create the ghost user and group, but won't actually make the ghost::blog resource. Adding a create_resource with the parameters will fix this issue :+1:
