### PR TITLE
0.4 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:14.04
+MAINTAINER Andrew Schwartzmeyer <andrew@schwartzmeyer.com>
+
+ADD https://apt.puppetlabs.com/puppetlabs-release-trusty.deb /tmp/
+RUN dpkg -i /tmp/puppetlabs-release-trusty.deb
+RUN apt-get update && apt-get install -y puppet
+RUN puppet --version
+
+COPY pkg/andschwa-ghost-0.3.1.tar.gz /tmp/
+RUN puppet module install puppetlabs/stdlib --version 4.6.0
+RUN puppet module install puppetlabs/nodejs --version 0.8.0
+RUN puppet module install puppetlabs/apt
+RUN puppet module install proletaryo/supervisor --version 0.4.0
+RUN puppet module install --ignore-dependencies /tmp/andschwa-ghost-0.3.1.tar.gz
+RUN puppet apply -e "class { '::nodejs': manage_package_repo => true, npm_package_ensure => 'present' } -> class { 'ghost': } -> ghost::blog { 'my_blog': }"
+
+EXPOSE 2368

--- a/README.md
+++ b/README.md
@@ -92,14 +92,22 @@ $include_nodejs = false,                         # Whether or not setup should i
 
 It delegates the user and group resources to `ghost::setup`, which
 creates the user and group you specify (ghost by default) and installs
-nodejs and `npm` using the
+Node.js and `npm` using the
 [puppetlabs-nodejs](https://forge.puppetlabs.com/puppetlabs/nodejs)
 module.
 
 Ghost requires an up-to-date nodejs, which can be done automatically
 by setting that class's `manage_repo` parameter to true. If the
 `nodejs` class is not defined elsewhere, this module will simply
-include it.
+include it. Unfortunately, you probably need to force the install of
+`npm` and the updated version of Node.js, like so:
+
+```puppet
+class { '::nodejs':
+  manage_package_repo => true,
+  npm_package_ensure => 'present'
+}
+```
 
 The module has one main resource, `ghost::blog`, with the following
 parameters:
@@ -137,7 +145,7 @@ You will likely want to proxy the Ghost instance using, say,
 other operating systems as well.
 
 * If managing the blog's `config.js` via this module, you cannot
-currently setup custom databases
+currently setup custom databases.
 
 * The socket file created by Ghost must be readable by the web server
 (perhaps Nginx) for communication to take place, but its default

--- a/README.md
+++ b/README.md
@@ -91,8 +91,10 @@ $include_nodejs = false,                         # Whether or not setup should i
 ```
 
 It delegates the user and group resources to `ghost::setup`, which
-creates the user and group you specify (ghost by default) and installs nodejs
-and NPM using the puppetlabs-nodejs module.
+creates the user and group you specify (ghost by default) and installs
+nodejs and `npm` using the
+[puppetlabs-nodejs](https://forge.puppetlabs.com/puppetlabs/nodejs)
+module.
 
 Ghost requires an up-to-date nodejs, which can be done automatically
 by setting that class's `manage_repo` parameter to true. If the
@@ -107,18 +109,15 @@ $user   = 'ghost',                          # Ghost instance should run as its o
 $group  = 'ghost',
 $home   = "/home/ghost/${title}",           # Root of Ghost instance (will be created if itdoesnot already exist)
 $source = 'https://ghost.org/zip/ghost-latest.zip', # Source for ghost distribution
-# The npm registry on some distributions needs to be set
-$manage_npm_registry = true,                          # Whether or not to attempt to set thenpmregistry (often needed)
-$npm_registry        = 'https://registry.npmjs.org/', # User's npm registry
 $use_supervisor = true, # User supervisor module to setup service for blog
 $autorestart    = true, # Restart on crash
 $stdout_logfile = "/var/log/ghost_${title}.log",
 $stderr_logfile = "/var/log/ghost_${title}_err.log",
 $manage_config = true, # Manage Ghost's config.js
 $url    = 'https://my-ghost-blog.com', # Required URL of blog
-$socket = true,                        # Set to false to use host and port
 $host   = '127.0.0.1',                 # Host to listen on if not using socket
 $port   = '2368',                      # Port of host to listen on
+$socket = false,                       # Set to false to use host and port
 $transport    = '', # Mail transport
 $fromaddress  = '', # Mail from address
 $mail_options = {}, # Hash for mail options
@@ -144,11 +143,34 @@ currently setup custom databases
 (perhaps Nginx) for communication to take place, but its default
 permissions of 660 do not allow this. Because the Ghost server creates
 the socket file on each launch, it is impossible to control its
-permissions through Puppet. The best solution to this predicament [(see issue #14)](https://github.com/andschwa/puppet-ghost/issues/14) is to add your web server's user to Ghost's group (e.g. `usermod -a -G ghost www-data`), which will allow it to read the socket.
+permissions through Puppet. The best solution to this predicament
+[(see issue #14)](https://github.com/andschwa/puppet-ghost/issues/14)
+is to add your web server's user to Ghost's group (e.g. `usermod -a -G
+ghost www-data`), which will allow it to read the socket.
 
 * If supervisor is not registering the blogs, restarting your system is
 the easiest solution (as always), but you should also try
 `supervisorctrl reread && supervisorctl reload`.
+
+## Upgrading from 0.3.x
+
+The `npm` registry management has been removed. If more advanced setup
+of Node.js is required, use the
+[puppetlabs/nodejs](https://forge.puppetlabs.com/puppetlabs/nodejs)
+module directly.
+
+The blog resource now uses host and port by default, same as Ghost's
+defaults. If you were using sockets and would like to continue to do
+so, set the appropriate parameter explicitly:
+
+```
+ghost::blog { 'my_blog':
+    socket => true
+}
+```
+
+Beware that supervisord will be replaced with systemd in the 1.0.0
+release.
 
 ## Upgrading from 0.2.x
 

--- a/manifests/blog.pp
+++ b/manifests/blog.pp
@@ -125,7 +125,7 @@ define ghost::blog(
 
   if $use_supervisor {
     supervisor::program { "ghost_${blog}":
-      command        => "node ${home}/index.js",
+      command        => "nodejs ${home}/index.js",
       autorestart    => $autorestart,
       user           => $user,
       group          => $group,

--- a/manifests/blog.pp
+++ b/manifests/blog.pp
@@ -25,10 +25,6 @@ define ghost::blog(
   $home   = "/home/ghost/${title}",                   # Root of Ghost instance (will be created if it does not already exist)
   $source = 'https://ghost.org/zip/ghost-latest.zip', # Source for ghost distribution
 
-  # The npm registry on some distributions needs to be set
-  $manage_npm_registry = true,                          # Whether or not to attempt to set the npm registry (often needed)
-  $npm_registry        = 'https://registry.npmjs.org/', # User's npm registry
-
   # Use [supervisor](http://supervisord.org/) to manage Ghost, with logging
   $use_supervisor = true, # User supervisor module to setup service for blog
   $autorestart    = true, # Restart on crash
@@ -55,8 +51,6 @@ define ghost::blog(
   validate_string($group)
   validate_absolute_path($home)
   validate_string($source)
-  validate_bool($manage_npm_registry)
-  validate_string($npm_registry)
   validate_bool($use_supervisor)
   validate_bool($autorestart)
   validate_absolute_path($stdout_logfile)
@@ -91,14 +85,6 @@ define ghost::blog(
 
   file { $home:
     ensure  => directory,
-  }
-
-  if $manage_npm_registry {
-    exec { "npm_config_set_registry_${blog}":
-      command => "npm config set registry ${npm_registry}",
-      unless  => "npm config get registry | grep ${npm_registry}",
-      before  => Exec["npm_install_ghost_${blog}"],
-    }
   }
 
   ensure_packages(['unzip', 'curl'])

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -11,7 +11,7 @@
 class ghost::setup {
 
   if $::ghost::include_nodejs {
-    include nodejs
+    include '::nodejs'
   }
 
   group { $ghost::group:

--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.1.0 < 5.0.0" },
-    { "name": "puppetlabs/nodejs", "version_requirement": ">= 0.6.1 < 2.0.0" },
+    { "name": "puppetlabs/nodejs", "version_requirement": ">= 0.8.0 < 1.0.0" },
     { "name": "proletaryo/supervisor", "version_requirement": ">= 0.4.0 < 0.5.0" }
   ]
 }


### PR DESCRIPTION
@petems maybe you can help me with this.

I'm working on a 0.4 release (now that I can actually test, thanks to Docker), skipping 0.3.1 because it's been so long and these updates are a bit more substantial, but have run into a couple issues.

On Ubuntu 14.04, with the up-to-date version of Node.js and `npm` that the Puppet Labs module installs, the binary `node` is actually `nodejs`, which is fine except for we'll need to check CentOS and potentially handle this on an OS basis.

The other problem is that the `npm install --production` is just flat-out failing for me (specifically on the sqlite step). It's probably just an issue with my test environment, but since I can't prove the module works yet, I'm opening this up for discussion.