### PR TITLE
Fixes rubocop errors

### DIFF
--- a/spec/acceptance/blog_spec.rb
+++ b/spec/acceptance/blog_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'ghost class' do
-
   context 'default parameters' do
     # Using puppet_apply as a helper
     it 'should work idempotently with no errors' do
@@ -28,7 +27,7 @@ describe 'ghost class' do
     end
 
     describe command('ls -al /home/ghost/my_blog') do
-      its(:stdout) { should match /README.md/ }
+      its(:stdout) { should match(/README.md/) }
     end
 
     context 'Ghost should be running on the default port' do
@@ -37,9 +36,8 @@ describe 'ghost class' do
       end
 
       describe command('curl 0.0.0.0:2368/') do
-        its(:stdout) { should match /Redirecting to https:\/\/my-ghost-blog.com\// }
+        its(:stdout) { should match %r{Redirecting to https:\/\/my-ghost-blog.com\/} }
       end
     end
-
   end
 end

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'ghost class' do
-
   context 'default parameters' do
     # Using puppet_apply as a helper
     it 'should work idempotently with no errors' do

--- a/spec/classes/example_spec.rb
+++ b/spec/classes/example_spec.rb
@@ -8,8 +8,8 @@ describe 'ghost' do
           facts
         end
 
-        context "ghost class without any parameters" do
-          let(:params) {{ }}
+        context 'ghost class without any parameters' do
+          let(:params) { {} }
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_user('ghost') }
           it { is_expected.to contain_group('ghost') }

--- a/spec/defines/blog_spec.rb
+++ b/spec/defines/blog_spec.rb
@@ -3,18 +3,18 @@ describe 'ghost::blog', :type => :define do
   let :facts do {
     :osfamily   => 'Debian',
     :lsbdistid  => 'Debian',
-    :lsbrelease => 'wheezy',
-  } end
+    :lsbrelease => 'wheezy'
+  }
+  end
 
   let(:title) { 'my_blog' }
 
-  describe "defaults" do
+  describe 'defaults' do
     it {
-      should contain_exec("curl_ghost_my_blog")
+      should contain_exec('curl_ghost_my_blog')
     }
     it {
-      should contain_exec("unzip_ghost_my_blog")
+      should contain_exec('unzip_ghost_my_blog')
     }
   end
-
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -24,11 +24,11 @@ RSpec.configure do |c|
     # Install module and dependencies
     hosts.each do |host|
       copy_module_to(host, :source => proj_root, :module_name => 'ghost')
-      on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0] }
-      on host, puppet('module', 'install', 'puppet-nodejs --version 1.3.0'), { :acceptable_exit_codes => [0] }
-      on host, puppet('module', 'install', 'proletaryo-supervisor --version 0.4.0'), { :acceptable_exit_codes => [0] }
+      on host, puppet('module', 'install', 'puppetlabs-stdlib'), :acceptable_exit_codes => [0]
+      on host, puppet('module', 'install', 'puppet-nodejs --version 1.3.0'), :acceptable_exit_codes => [0]
+      on host, puppet('module', 'install', 'proletaryo-supervisor --version 0.4.0'), :acceptable_exit_codes => [0]
       if fact('osfamily') == 'Debian'
-        shell('puppet module install puppetlabs-apt', { :acceptable_exit_codes => [0,1] })
+        shell('puppet module install puppetlabs-apt', :acceptable_exit_codes => [0, 1])
       end
     end
   end


### PR DESCRIPTION
Note: I don't agree with ` Avoid comma after the last item of a hash.` in `defines/blog_spec.rb:6`. Opening PR to change: https://github.com/voxpupuli/modulesync_config/pull/86