### PR TITLE
Bump min version_requirement for Puppet + deps

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,12 +9,8 @@
   "issues_url": "https://github.com/voxpupuli/puppet-ghost/issues",
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": "3.x"
-    },
-    {
       "name": "puppet",
-      "version_requirement": ">= 3.3.0"
+      "version_requirement": ">= 3.8.7 < 4.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -36,7 +32,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.1.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     },
     {
       "name": "puppet/nodejs",
@@ -44,7 +40,7 @@
     },
     {
       "name": "proletaryo/supervisor",
-      "version_requirement": ">= 0.4.0 < 0.5.0"
+      "version_requirement": ">= 0.5.3 < 2.0.0"
     }
   ]
 }


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions

Bump dependencies to the minimum version that should work under
Puppet 4, based on the metadata

Also remove deprecated pe version_requirement field