### PR TITLE
Docs fixes - update docs and use puppet strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # puppet-ghost [![Build Status](https://travis-ci.org/voxpupuli/puppet-ghost.svg?branch=master)](https://travis-ci.org/voxpupuli/puppet-ghost)
 
-Donated by the excellet [@andschwa](https://twitter.com/andschwa)
+Donated by the excellent [@andschwa](https://twitter.com/andschwa)
 
 #### Table of Contents
 
 1. [Overview](#overview)
 2. [Module Description](#module-description)
-3. [Setup - The basics of getting started with andschwa-ghost](#setup)
-    * [What andschwa-ghost affects](#what-andschwa-ghost-affects)
-    * [Beginning with andschwa-ghost](#beginning-with-andschwa-ghost)
+3. [Setup - The basics of getting started with ghost](#setup)
+    * [What ghost affects](#what-ghost-affects)
+    * [Beginning with ghost](#beginning-with-ghost)
 4. [Usage - Configuration options and additional functionality](#usage)
 5. [Limitations - OS compatibility, etc.](#limitations)
 6. [Development - Guide for contributing to the module](#development)
@@ -35,7 +35,7 @@ class, adds the ghost user and group, and finally starts ghost.
 
 ## Setup
 
-### What andschwa-ghost affects
+### What ghost affects
 
 * Packages
   * `nodejs`
@@ -53,7 +53,7 @@ class, adds the ghost user and group, and finally starts ghost.
 * Group
     * `ghost`
 
-### Beginning with andschwa-ghost
+### Beginning with ghost
 
 The simplest use of this module is:
 
@@ -70,15 +70,23 @@ defaults and hosted by nginx, you can use the
 [ghost_blog_profile](https://github.com/petems/petems-ghost_blog_profile). This
 uses this module and sets up a ghost blog to work end-to-end.
 
-```
+```puppet
 class { 'ghost_blog_profile::basic':
   blog_name => 'my_blog',
 }
 ```
 
-Here is an alternative
-[Puppet profile](https://github.com/andschwa/puppet-profile/blob/master/manifests/ghost.pp)
-for a Ghost blog with Nginx.
+Here is an alternative Puppet profile for a Ghost blog with Nginx.
+```puppet
+class profile::ghost {
+  include profile::web
+
+  include nodejs
+
+  include ::ghost
+  create_resources('ghost::blog', hiera_hash('ghost::blogs', {}))
+}
+```
 
 ### Usage
 

--- a/manifests/blog.pp
+++ b/manifests/blog.pp
@@ -1,56 +1,56 @@
-# == Class: ghost::blog
+# ghost::blog
 #
-# This class sets up a Ghost blog instance. The user and group must
-# exist (can be created with the base class), and nodejs and npm must
-# be installed.
+# @summary This class sets up a Ghost blog instance.
+#
+# The user and group must exist (can be created with the base class), and
+# nodejs and npm must be installed.
 #
 # It will install the latest version of Ghost. Subsequent updates can
 # be forced by deleting the archive.
 #
 # It can also daemonize the Ghost blog instance using supervisor.
 #
-# === Copyright
+# @param blog Name of blog
+# @param user Username for ghost instance to run under
+# @param group Group for ghost instance to run under
+# @param home Root of Ghost instance (will be created if it does not already exist)
+# @param source Source for ghost distribution
+# @param manage_npm_registry Whether or not to attempt to set the npm registry (often needed)
+# @param npm_registry User's npm registry
+# @param use_supervisor Use supervisor module to setup service for blog
+# @param autorestart Restart on crash
+# @param stdout_logfile Logfile for stdout
+# @param stderr_logfile Logfile for stderr
+# @param manage_config Manage Ghost's config.js
+# @param url Required URL of blog (must be unique)
+# @param host Host to listen on if not using socket
+# @param port Port to listen on
+# @param socket Use a socket instead if true
+# @param transport Mail transport
+# @param fromaddress Mail from address
+# @param mail_options Hash for mail options
 #
 # Copyright 2014 Andrew Schwartzmeyer
-#
-# === TODO
-#
-# - add database setup to template
-# - support other operating systems
-
 define ghost::blog(
-  String $blog                                   = $title, # Name of blog
-  String $user                                   = 'ghost', # Ghost instance should run as its own user
+  String $blog                                   = $title,
+  String $user                                   = 'ghost',
   String $group                                  = 'ghost',
   Stdlib::Absolutepath $home                     = "/home/ghost/${title}",
-  # Root of Ghost instance (will be created if it does not already exist)
   Stdlib::HTTPSUrl $source                       = 'https://ghost.org/zip/ghost-latest.zip',
-  # Source for ghost distribution
-
-  # The npm registry on some distributions needs to be set
   Boolean $manage_npm_registry                   = true,
-  # Whether or not to attempt to set the npm registry (often needed)
-  Stdlib::HTTPSUrl $npm_registry                 = 'https://registry.npmjs.org/', # User's npm registry
-
-  # Use [supervisor](http://supervisord.org/) to manage Ghost, with logging
-  Boolean $use_supervisor                        = true, # User supervisor module to setup service for blog
-  Boolean $autorestart                           = true, # Restart on crash
+  Stdlib::HTTPSUrl $npm_registry                 = 'https://registry.npmjs.org/',
+  Boolean $use_supervisor                        = true,
+  Boolean $autorestart                           = true,
   Stdlib::Absolutepath $stdout_logfile           = "/var/log/ghost_${title}.log",
   Stdlib::Absolutepath $stderr_logfile           = "/var/log/ghost_${title}_err.log",
-
-  # Parameters below affect Ghost's config through the template
-  Boolean $manage_config                         = true, # Manage Ghost's config.js
-
-  # For a working blog, these must be specified and different per instance
-  Stdlib::HTTPSUrl $url                          = 'https://my-ghost-blog.com', # Required URL of blog
-  String $host                                   = '127.0.0.1', # Host to listen on if not using socket
-  Integer $port                                  = 2368, # Port of host to listen on
-  Variant[Boolean, Stdlib::Absolutepath] $socket = false, # True will use a socket instead
-
-  # Mail settings (see http://docs.ghost.org/mail/)
-  String $transport                              = '', # Mail transport
-  String $fromaddress                            = '', # Mail from address
-  Hash $mail_options                             = {}, # Hash for mail options
+  Boolean $manage_config                         = true,
+  Stdlib::HTTPSUrl $url                          = 'https://my-ghost-blog.com',
+  String $host                                   = '127.0.0.1',
+  Integer $port                                  = 2368,
+  Variant[Boolean, Stdlib::Absolutepath] $socket = false,
+  String $transport                              = '',
+  String $fromaddress                            = '',
+  Hash $mail_options                             = {},
 ) {
 
   Exec {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,6 @@
-# == Class: ghost
+# ghost
+#
+# @summary A module to manage the Ghost blog platform
 #
 # This class sets up a default Ghost user that can be used (and is by
 # default) to separate the permissions of blogs. This class is
@@ -9,19 +11,20 @@
 # however, on operating systems with out-of-date packages, you may
 # need to set nodejs::manage_repo to true.
 #
-# Deprecation notice: the create_resources with hiera_hash has been
-# deprecated, see [issue
-# #16](https://github.com/andschwa/puppet-ghost/issues/16); please
-# setup your own resource creation in your roles/profiles.
+# @param user Default ghost username
+# @param group Default ghost group
+# @param home Ghost user's home directory, default base for blogs
+# @param include_nodejs Whether or not setup should include nodejs module
 #
 # === Copyright
 #
 # Copyright 2014 Andrew Schwartzmeyer
+#
 class ghost(
-  String $user               = 'ghost',       # Ghost should run as its own user
-  String $group              = 'ghost',       # Ghost GID and group to create
-  Stdlib::Absolutepath $home = '/home/ghost', # Ghost user's home directory, default base for blogs
-  Boolean $include_nodejs    = false,         # Whether or not setup should include nodejs module
+  String $user               = 'ghost',
+  String $group              = 'ghost',
+  Stdlib::Absolutepath $home = '/home/ghost',
+  Boolean $include_nodejs    = false,
   ) {
 
   contain ghost::setup

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -1,14 +1,12 @@
-# == Class: ghost::setup
+# ghost::setup
 #
-# This class includes nodejs if not already defined, and creates the
-# ghost user and group. It is not meant to be used directly, but
-# included from the base Ghost class.
-#
-# === Copyright
+# @summary This class includes nodejs if not already defined, and creates the
+#  ghost user and group. Private class.
 #
 # Copyright 2014 Andrew Schwartzmeyer
-
 class ghost::setup {
+
+  assert_private()
 
   if $ghost::include_nodejs {
     include nodejs

--- a/templates/config.js.erb
+++ b/templates/config.js.erb
@@ -13,10 +13,10 @@ config = {
         url: '<%= @url %>',
 
         mail: {
-            <% if defined? @transport -%>
+            <% if @transport -%>
             transport: '<%= @transport %>',
             <% end -%>
-            <% if defined? @fromaddress -%>
+            <% if @fromaddress -%>
             fromaddress: '<%= @fromaddress %>',
             <% end -%>
             options: {


### PR DESCRIPTION
This documents params in puppet strings instead of comments, and does some other basic docs fixes.
It also makes the mail related params in the blog defined type optional instead of defaulting to empty strings.